### PR TITLE
Added travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
+  - openjdk6
+


### PR DESCRIPTION
AL-SIGM repo is active in travis-ci, but the travis configuration file is needed. This is the first version to build AL-SIGM using OracleJDK8, OracleJDK7, OpenJDK7 and OpenJDK6